### PR TITLE
Add support for Windows code signing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -125,15 +125,41 @@ jobs:
         run: |
           npm install
 
-      - name: Publish releases - Windows
+      - name: Prepare release - Windows
         # If the branch is labeled as a release version (e.g. "release/v1.2.3"),
         if: ${{ matrix.os == env.OS_WINDOWS && startsWith(github.ref, 'refs/heads/release/v') && contains(github.ref, '.') }}
         env:
-          # set the build script to publish the builds
-          BUILD_PUBLISH: true
-          # This is used for uploading release assets to github
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm run build-ci
+        run: |
+          npm run build-ci
+          mkdir temp-build\\paranext-core\\release\\staged
+          move temp-build\\paranext-core\\release\\build\\*Setup*.exe temp-build\\paranext-core\\release\\staged
+
+      # If you need to sign Windows installers, enter the necessary secrets and uncomment this block
+      # - name: Code signing - Windows
+      # if: ${{ matrix.os == env.OS_WINDOWS && startsWith(github.ref, 'refs/heads/release/v') && contains(github.ref, '.') }}
+      # See https://github.com/cognitedata/code-sign-action/blob/main/README.md for descriptions
+      # env:
+      #   CERTIFICATE_HOST: ${{ secrets.WIN_CODE_SIGNING_CERT_HOST }}
+      #   CERTIFICATE_HOST_API_KEY: ${{ secrets.WIN_CODE_SIGNING_CERT_HOST_API_KEY }}
+      #   CERTIFICATE_SHA1_HASH: ${{ secrets.WIN_CERTIFICATE_SHA1_HASH }}
+      #   CLIENT_CERTIFICATE: ${{ secrets.WIN_CODE_SIGNING_CLIENT_CERT }}
+      #   CLIENT_CERTIFICATE_PASSWORD: ${{ secrets.WIN_CODE_SIGNING_CLIENT_CERT_PASSWORD }}
+      #   KEYPAIR_ALIAS: ${{ secrets.WIN_CODE_SIGNING_KEYPAIR_ALIAS }}
+      # uses: cognitedata/code-sign-action/@v3
+      # with:
+      #   path-to-binary: 'temp-build\\paranext-core\\release\\staged'
+
+      - name: Publish release - Windows
+        if: ${{ matrix.os == env.OS_WINDOWS && startsWith(github.ref, 'refs/heads/release/v') && contains(github.ref, '.') }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: 'Windows-PlatformBible-${{ steps.package_json.outputs.version }}'
+          path: temp-build/paranext-core/release/staged
+          if-no-files-found: error
+          compression-level: 0
 
       - name: Publish releases - macOS
         # If the branch is labeled as a release version (e.g. "release/v1.2.3"),

--- a/README.md
+++ b/README.md
@@ -244,6 +244,19 @@ If Git unexpectedly asks you for credentials while running builds, it is likely 
 - Provide your username and a [personal access token](https://github.com/settings/personal-access-tokens) to Git.
 - If you prefer to use SSH authentication with GitHub, you need to change the uris for the private repos in `productInfo.json` to point to the SSH uris for those repos.
 
+### Windows installers are not signed by a certificate
+
+If you want your Windows installer to be signed by a certificate so it is trusted by Windows, you need to obtain a certificate from a trusted certificate provider like [digicert](https://www.digicert.com/). If you use digicert specifically, then you can add the following secrets to your repo in GitHub and uncomment the [`Code signing - Windows` block in `publish.yml`](.github/workflows/publish.yml#L139):
+
+- WIN_CERTIFICATE_SHA1_HASH
+- WIN_CODE_SIGNING_CERT_HOST
+- WIN_CODE_SIGNING_CERT_HOST_API_KEY
+- WIN_CODE_SIGNING_CLIENT_CERT
+- WIN_CODE_SIGNING_CLIENT_CERT_PASSWORD
+- WIN_CODE_SIGNING_KEYPAIR_ALIAS
+
+If you use a certificate provider other than digicert, you will need to add a step to your publishing workflow that handles the signing process used by that certificate provider. The commented out step in `publish.yml` will only work with digicert certificates.
+
 ## JavaScript Tool Manager
 
 You can use [Volta](https://volta.sh/) with this repo to use the right version of tools such as **node** and **npm**.


### PR DESCRIPTION
This applies similar changes to `paranext` [that were made to `paranext-core`](https://github.com/paranext/paranext-core/pull/1457). In this case, though, the code signing block is disabled since we don't want to sign Windows installers from this repo by default. That will be up to applications to configure that derive from this repo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext/35)
<!-- Reviewable:end -->
