### PR TITLE
Update Linux workflows for working with snap packages

### DIFF
--- a/.github/workflows/package-main.yml
+++ b/.github/workflows/package-main.yml
@@ -181,7 +181,7 @@ jobs:
         with:
           name: app-linux
           path: |
-            ./dist/*.AppImage
+            ./dist/*.snap
 
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       - name: Setup tmate session

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -164,13 +164,13 @@ jobs:
       - name: Publish releases - macOS
         # If the branch is labeled as a release version (e.g. "release/v1.2.3"),
         if: ${{ matrix.os == env.OS_MACOS && startsWith(github.ref, 'refs/heads/release/v') && contains(github.ref, '.') }}
-        env:
-          # The APPLE_* values are used for auto updates signing
-          # APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          # APPLE_ID: ${{ secrets.APPLE_ID }}
-          # APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          # CSC_LINK: ${{ secrets.CSC_LINK }}
-          # CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        # env:
+        # The APPLE_* values are used for auto updates signing
+        # APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+        # APPLE_ID: ${{ secrets.APPLE_ID }}
+        # APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        # CSC_LINK: ${{ secrets.CSC_LINK }}
+        # CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
         run: npm run build-ci
 
       - name: Upload macOS artifacts
@@ -181,22 +181,38 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: 'macOS-PlatformBible-${{ steps.package_json.outputs.version }}'
-          path: |
-            ./dist/*.dmg
+          path: ./dist/*.dmg
           if-no-files-found: error
           compression-level: 0
 
-      - name: Publish releases - Linux
+      - name: Publish releases to the snap store - Linux
         # If the branch is labeled as a release version (e.g. "release/v1.2.3"),
         if: ${{ matrix.os == env.OS_LINUX && startsWith(github.ref, 'refs/heads/release/v') && contains(github.ref, '.') }}
         env:
-          # set the build script to publish the builds
-          BUILD_PUBLISH: true
-          # no hardlinks so dependencies are copied
+          # no hard links so dependencies are copied
           USE_HARD_LINKS: false
-          # This is used for uploading release assets to github
+          # This is used by electron-builder to prepare the release
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm run build-ci
+          # This is required to upload automatically to the snap store
+          # SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.LINUX_SNAP_STORE_CREDENTIALS }}
+        # Once snap store credentials are set, add the following line right after `npm run build-ci`
+        # snapcraft upload --release=edge ./temp-build/paranext-core/release/build/*.snap
+        run: |
+          npm run build-ci
+          mkdir ./temp-build/paranext-core/release/staged
+          mv ./temp-build/paranext-core/release/build/*.snap ./temp-build/paranext-core/release/staged
+
+      - name: Upload Linux artifacts to GitHub
+        # If the branch is labeled as a release version (e.g. "release/v1.2.3"),
+        if: ${{ matrix.os == env.OS_LINUX && startsWith(github.ref, 'refs/heads/release/v') && contains(github.ref, '.') }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: 'Linux-PlatformBible-${{ steps.package_json.outputs.version }}'
+          path: release/staged
+          if-no-files-found: error
+          compression-level: 0
 
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       - name: Setup tmate session

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ If you would still like to try Platform.Bible, you can [download early releases 
 ### Linux Users
 
 We can produce [`snap` packages](<https://en.wikipedia.org/wiki/Snap_(software)>) available [on the snap store](https://snapcraft.io/) for users to run our
-software on Linux. Once you have all the `snap` tools installed for your flavor of Linux, run `sudo snap install <your snap name>` or `sudo snap install <your snap name> --channel=edge` for our most recent, pre-release build that has passed our limited, automated testing suite.
+software on Linux. Once you have all the `snap` tools installed for your flavor of Linux, run `sudo snap install <snap name>` or `sudo snap install <snap name> --channel=edge` for our most recent, pre-release build that has passed our limited, automated testing suite.
 
 To install a locally created `snap` package, run the following commands:
 
 ```sh
 sudo snap install <path to snap file> --dangerous
-sudo snap connect <your snap name>:dot-<your snap name>
+sudo snap connect <snap name>:dot-<snap name>
 ```
 
 Some users may find that not everything works properly in Linux without some additional setup. Please see [How to set up Platform.Bible on Linux](https://github.com/paranext/paranext/wiki/How-to-set-up-Platform.Bible-on-Linux) for more information.

--- a/README.md
+++ b/README.md
@@ -30,13 +30,17 @@ If you would still like to try Platform.Bible, you can [download early releases 
 
 ### Linux Users
 
-To use `.AppImage` files in Linux, [install FUSE](https://github.com/AppImage/AppImageKit/wiki/FUSE) (you only need to do this once), for example, on Ubuntu (>= 22.04):
+We can produce [`snap` packages](<https://en.wikipedia.org/wiki/Snap_(software)>) available [on the snap store](https://snapcraft.io/) for users to run our
+software on Linux. Once you have all the `snap` tools installed for your flavor of Linux, run `sudo snap install <your snap name>` or `sudo snap install <your snap name> --channel=edge` for our most recent, pre-release build that has passed our limited, automated testing suite.
 
-```bash
-sudo apt install libfuse2
+To install a locally created `snap` package, run the following commands:
+
+```sh
+sudo snap install <path to snap file> --dangerous
+sudo snap connect <your snap name>:dot-<your snap name>
 ```
 
-Then simply [execute/run](https://github.com/AppImage/AppImageKit/wiki) the `.AppImage` file, which you can download from [Releases](https://github.com/paranext/paranext/releases).
+Some users may find that not everything works properly in Linux without some additional setup. Please see [How to set up Platform.Bible on Linux](https://github.com/paranext/paranext/wiki/How-to-set-up-Platform.Bible-on-Linux) for more information.
 
 ### Mac Users
 

--- a/cspell.json
+++ b/cspell.json
@@ -42,6 +42,7 @@
     "reinitializing",
     "reserialized",
     "sillsdev",
+    "snapcraft",
     "steenwyk",
     "stringifiable",
     "Stylesheet",


### PR DESCRIPTION
This is mostly copying over work from https://github.com/paranext/paranext-core/pull/1473 to this repo. This is in preparation for updating the `paratext-10-studio` repo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext/38)
<!-- Reviewable:end -->
