### PR TITLE
get productName from releaseAppPackage instead of electron config

### DIFF
--- a/lib/build.ts
+++ b/lib/build.ts
@@ -218,7 +218,6 @@ console.log('Build steps enabled:', {
     const electronBuilderConfig = json5.parse(electronBuilderConfigJson5);
 
     // Update product details
-    electronBuilderConfig.productName = productInfo.productName;
     electronBuilderConfig.appId = productInfo.appId;
     electronBuilderConfig.copyright = productInfo.copyright;
     electronBuilderConfig.publish = productInfo.electronBuilderPublish;
@@ -285,6 +284,7 @@ console.log('Build steps enabled:', {
 
     // Update product details
     releaseAppPackage.name = productInfo.name;
+    releaseAppPackage.productName = productInfo.productName;
     releaseAppPackage.version = productInfo.version;
     releaseAppPackage.description = productInfo.description;
     releaseAppPackage.author = productInfo.author;


### PR DESCRIPTION
In https://github.com/paranext/paranext-core/pull/1472 I moved `productName` from the electron configuration json to `release/app/package.json`. This PR fixes where we get `productName` in `build.ts`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext/45)
<!-- Reviewable:end -->
