### PR TITLE
Look for `productName` in electron config and not package.json

### DIFF
--- a/lib/build.ts
+++ b/lib/build.ts
@@ -218,6 +218,7 @@ console.log('Build steps enabled:', {
     const electronBuilderConfig = json5.parse(electronBuilderConfigJson5);
 
     // Update product details
+    electronBuilderConfig.productName = productInfo.productName;
     electronBuilderConfig.appId = productInfo.appId;
     electronBuilderConfig.copyright = productInfo.copyright;
     electronBuilderConfig.publish = productInfo.electronBuilderPublish;
@@ -284,7 +285,6 @@ console.log('Build steps enabled:', {
 
     // Update product details
     releaseAppPackage.name = productInfo.name;
-    releaseAppPackage.productName = productInfo.productName;
     releaseAppPackage.version = productInfo.version;
     releaseAppPackage.description = productInfo.description;
     releaseAppPackage.author = productInfo.author;


### PR DESCRIPTION
To resolve https://paratextstudio.atlassian.net/browse/PT-3065

Removed productName from release/app/package.json and put it back into the electron builder config.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext/47)
<!-- Reviewable:end -->
