### PR TITLE
Change Github macOS runner version from latest to 14

### DIFF
--- a/.github/workflows/package-main.yml
+++ b/.github/workflows/package-main.yml
@@ -3,7 +3,7 @@ name: Package
 # Make sure these match with the matrix.os values below
 env:
   OS_WINDOWS: windows-latest
-  OS_MACOS: macos-latest
+  OS_MACOS: macos-14
   # The Ubuntu version must align with the "core" version in electron-builder.json5 in paranext-core
   OS_LINUX: ubuntu-22.04
 
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         # Make sure these match with the env values above
-        os: [windows-latest, macos-latest, ubuntu-22.04]
+        os: [windows-latest, macos-14, ubuntu-22.04]
         dotnet_version: [8.0.x]
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ run-name: Publish release v${{ github.event.inputs.version }} on ${{ github.head
 # Make sure these match with the matrix.os values below
 env:
   OS_WINDOWS: windows-latest
-  OS_MACOS: macos-latest
+  OS_MACOS: macos-14
   # The Ubuntu version must align with the "core" version in electron-builder.json5 in paranext-core
   OS_LINUX: ubuntu-22.04
 
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         # Make sure these match with the env values above
-        os: [windows-latest, macos-latest, ubuntu-22.04]
+        os: [windows-latest, macos-14, ubuntu-22.04]
         dotnet_version: [8.0.x]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 # Make sure these match with the matrix.os values below
 env:
   OS_WINDOWS: windows-latest
-  OS_MACOS: macos-latest
+  OS_MACOS: macos-14
   # The Ubuntu version must align with the "core" version in electron-builder.json5 in paranext-core
   OS_LINUX: ubuntu-22.04
 
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         # Make sure these match with the env values above
-        os: [windows-latest, macos-latest, ubuntu-22.04]
+        os: [windows-latest, macos-14, ubuntu-22.04]
         dotnet_version: [8.0.x]
 
     steps:


### PR DESCRIPTION
Solving build error with installing MacPorts. Believe it is related to the Github action we are using that does not support macOS 15 yet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext/56)
<!-- Reviewable:end -->
