### PR TITLE
PT-3107: Improve release workflow

### DIFF
--- a/.github/actions/bump-versions-action/action.yml
+++ b/.github/actions/bump-versions-action/action.yml
@@ -1,0 +1,25 @@
+name: Bump Versions Action
+description: |
+  Runs bump-versions.ts script
+
+inputs:
+  newVersion:
+    description: "Version to bump all the repo's versions to on a new branch (called `bump-versions-<version>`), e.g. 0.3.0-alpha.0."
+    required: true
+  newMarketingVersion:
+    description: 'Marketing Version to to set for the application on a new branch (called `bump-versions-<version>`), e.g. β1.7'
+    required: false
+  newMarketingVersionMoniker:
+    description: 'Marketing Version Moniker to to set for the application on a new branch (called `bump-versions-<version>`), e.g. Developer Preview.'
+    required: false
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Bump repo versions
+      # Bump versions using the built-in git token https://github.com/actions/checkout/tree/v4/?tab=readme-ov-file#push-a-commit-using-the-built-in-token
+      shell: bash
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        npm run bump-versions -- ${{ inputs.newVersion }} ${{ (inputs.newMarketingVersion != '' || inputs.newMarketingVersionMoniker != '') && format('--marketing-version "{0}" --marketing-version-moniker "{1}"', inputs.newMarketingVersion, inputs.newMarketingVersionMoniker) || '' }}

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -1,0 +1,59 @@
+name: Bump Versions
+run-name: Bump versions on ${{ github.head_ref || github.ref_name }} to ${{ github.event.inputs.newVersion }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      newVersion:
+        description: "Version to bump all the repo's versions to on a new branch (called `bump-versions-<version>`), e.g. 0.3.0-alpha.0."
+        required: true
+      newMarketingVersion:
+        description: 'Marketing Version to to set for the application on a new branch (called `bump-versions-<version>`), e.g. β1.7'
+        required: false
+      newMarketingVersionMoniker:
+        description: 'Marketing Version Moniker to to set for the application on a new branch (called `bump-versions-<version>`), e.g. Developer Preview.'
+        required: false
+
+jobs:
+  bump-versions:
+    name: Bump versions on ${{ matrix.os }}
+
+    runs-on: ${{ matrix.os }}
+
+    permissions:
+      contents: write
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+
+    steps:
+      - name: Output Workflow Dispatch Inputs
+        run: echo "${{ toJSON(github.event.inputs) }}"
+
+      - name: Checkout git repo
+        uses: actions/checkout@v4
+
+      - name: Read package.json
+        id: package_json
+        uses: zoexx/github-action-json-file-properties@1.0.6
+        with:
+          file_path: 'package.json'
+
+      - name: Install Node and NPM
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ fromJson(steps.package_json.outputs.volta).node }}
+          cache: npm
+
+      - name: Install packages
+        run: |
+          npm ci
+
+      - name: Bump repo versions
+        if: ${{ inputs.newVersion != '' }}
+        uses: ./.github/actions/bump-versions-action
+        with:
+          newVersion: ${{ inputs.newVersion }}
+          newMarketingVersion: ${{ inputs.newMarketingVersion }}
+          newMarketingVersionMoniker: ${{ inputs.newMarketingVersionMoniker }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,11 @@ on:
       bumpRef:
         description: 'Git ref to create the new `bump-versions-<version>` branch from. If empty, will use the current branch.'
         required: false
+      uploadReleaseAssets:
+        description: 'Upload the release assets to the configured S3 bucket.'
+        type: boolean
+        required: false
+        default: false
       debug_enabled:
         type: boolean
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
@@ -217,9 +222,29 @@ jobs:
           omitPrereleaseDuringUpdate: true
           # make the new release a pre-release
           prerelease: true
+          # tag+commit creates a version tag for this release with the tag name at the commit ref
+          # so the GitHub Release doesn't have to create the tag and assume it is on `main`
           tag: v${{ inputs.version }}
+          commit: ${{ github.head_ref || github.ref_name }}
           # only update if the release is still a draft
           updateOnlyUnreleased: true
+
+      - name: Upload release assets to S3
+        id: upload_s3
+        if: ${{ inputs.uploadReleaseAssets && matrix.os != env.OS_LINUX }}
+        uses: shallwefootball/upload-s3-action@v1.3.3
+        with:
+          aws_key_id: ${{ secrets.AWS_S3_RELEASE_ACCESS_KEY_ID }}
+          aws_secret_access_key: ${{ secrets.AWS_S3_RELEASE_SECRET_ACCESS_KEY}}
+          aws_bucket: ${{ vars.AWS_S3_RELEASE_BUCKET_NAME }}
+          source_dir: release/staged
+          # runner.os is Windows or macOS
+          destination_dir: ${{ vars.AWS_S3_RELEASE_DIRECTORY }}/${{ inputs.version}}/${{ runner.os }}
+
+      - name: Print S3 upload result
+        if: ${{ inputs.uploadReleaseAssets && matrix.os != env.OS_LINUX }}
+        run: |
+          echo "S3 upload object_key: ${{ steps.upload_s3.outputs.object_key }}; object_locations: ${{ steps.upload_s3.outputs.object_locations }}"
 
       - name: Checkout bump ref
         if: ${{ matrix.os == env.OS_LINUX && inputs.newVersionAfterPublishing != '' && inputs.bumpRef != '' && inputs.bumpRef != (github.head_ref || github.ref_name) }}
@@ -230,11 +255,9 @@ jobs:
 
       - name: Bump repo versions
         if: ${{ matrix.os == env.OS_LINUX && inputs.newVersionAfterPublishing != '' }}
-        # Bump versions using the built-in git token https://github.com/actions/checkout/tree/v4/?tab=readme-ov-file#push-a-commit-using-the-built-in-token
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          npm run bump-versions -- ${{ inputs.newVersionAfterPublishing }}
+        uses: ./.github/actions/bump-versions-action
+        with:
+          newVersion: ${{ inputs.newVersionAfterPublishing }}
 
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       - name: Setup tmate session

--- a/README.md
+++ b/README.md
@@ -219,25 +219,58 @@ This will also destroy [any changes and untracked files you have made to the rep
 
 These steps will walk you through releasing a version on GitHub and bumping the version to a new version so future changes apply to the new in-progress version.
 
-1. In each repository in your `productInfo.json`, create a release for the version you want to include in this repo's release. Then, set `branch` for each repo listed in `productInfo.json` to the tag corresponding to the release of that repo you want to include in this release. **DO NOT** leave `branch` as any kind of get ref that can change like a branch name. Otherwise, you will not be able to determine later exactly what code is included in the release.
-2. Make sure this repo's `package.json` version is on the version number you want to release. If it is not, run the `bump-versions` npm script to set the version to what you want to release. This script will create a branch named `bump-versions-<version>` from your current head with the needed changes. Open a PR and merge that new branch into the branch you plan to release from. For example, to bump branch `my-branch` to version 0.2.0, run the following:
-
-   ```bash
-   git checkout my-branch
-   npm run bump-versions 0.2.0
-   ```
-
-   Then create a PR and merge the `bump-versions-0.2.0` branch into `my-branch`. `my-branch` is now ready for release.
-
-3. Manually dispatch the Publish workflow in GitHub Actions targeting the branch you want to release from (in the previous example, this would be `my-branch`). This workflow creates a new pre-release for the version you intend to release and creates a new `bump-versions-<next_version>` branch to bump the version after the release so future changes apply to a new in-progress version instead of to the already released version. This workflow has the following inputs:
+1. In each repository in your `productInfo.json`, create a release for the version you want to include in this repo's release. Then, set `branch` for each repo listed in `productInfo.json` to the tag corresponding to the release of that repo you want to include in this release. **DO NOT** leave `branch` as any kind of Git ref that can change like a branch name. Otherwise, you will not be able to determine later exactly what code is included in the release.
+2. Make sure this repo's `package.json` version is on the version number you want to release. If it is not, manually dispatch the [Bump Versions workflow](#bumping-version-without-publishing-a-release) or run the `bump-versions` npm script to set the version to what you want to release on the branch you want to release from.
+3. Manually dispatch the Publish workflow in GitHub Actions targeting the branch you want to release from. This workflow creates a new pre-release for the version you intend to release and creates a new `bump-versions-<next_version>` branch to bump the version after the release so future changes apply to a new in-progress version instead of to the already released version. This workflow has the following inputs:
 
    - `version`: enter the version you intend to publish (e.g. 0.2.0). This is simply for verification to make sure you release the code that you intend to release. It is compared to the version in the code, and the workflow will fail if they do not match.
    - `newVersionAfterPublishing`: enter the version you want to bump to after releasing (e.g. 0.3.0-alpha.0). Future changes will apply to this new version instead of to the version that was already released. Leave blank if you don't want to bump
    - `bumpRef`: enter the Git ref you want to create the bump versions branch from, e.g. `main`. Leave blank if you want to use the branch selected for the workflow run. For example, if you release from a stable branch named `release-prep`, you may want to bump the version on `main` so future development work happens on the new version, then you can rebase `release-prep` onto `main` when you are ready to start preparing the next stable release.
+   - `uploadReleaseAssets`: whether to upload the release assets to [Amazon S3](https://aws.amazon.com/s3/). If false, the release will still be created in GitHub, but no assets will be uploaded to S3. In order to successfully upload the release assets to S3, you need to [set up some secrets and variables](#configure-uploading-release-assets-to-amazon-s3).
 
 4. In GitHub, adjust the new draft release's body and other metadata as desired, then publish the release.
 5. Open a PR and merge the newly created `bump-versions-<next_version>` branch.
 6. When appropriate, in [Snapcraft](https://snapcraft.io/platform-bible/releases), promote the newly uploaded release to the appropriate channel.
+
+### Configure uploading release assets to Amazon S3
+
+If you want to upload your release assets to [Amazon S3](https://aws.amazon.com/s3/) when running the [Publish](#publishing) workflow, you need to set up an [AWS access key](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html) and then configure some [repository secrets](https://github.com/paranext/paranext/settings/secrets/actions) and [repository variables](https://github.com/paranext/paranext/settings/variables/actions) in GitHub:
+
+1. Create an [AWS access key](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html) for a user with the following permissions:
+
+   - `s3:*` on the S3 bucket where the release assets should be uploaded and the files in the directory in which to put the release assets (see below for more information). There are likely narrower permissions you can set and still successfully upload the release assets.
+
+2. Set up the following [repository secrets and variables](https://github.com/paranext/paranext/settings/secrets/actions)
+
+   - Repository secrets:
+     - `AWS_S3_RELEASE_ACCESS_KEY_ID`: The access key ID for authenticating with AWS
+     - `AWS_S3_RELEASE_SECRET_ACCESS_KEY`: The secret access key for authenticating with AWS
+   - Repository variables:
+     - `AWS_S3_RELEASE_BUCKET_NAME`: The name of the S3 bucket where the release assets should be uploaded
+     - `AWS_S3_RELEASE_DIRECTORY`: The directory in which to put the release build directories. The builds themselves will be in `$AWS_S3_RELEASE_DIRECTORY/$RELEASE_VERSION/$RUNNER_OS/`
+
+Note: you can very likely use other levels of secrets and variables like organization-level, but this has not been tested.
+
+### Bumping version without publishing a release
+
+Sometimes, it may be useful to change the version without [publishing a release](#publishing).
+
+To bump versions without publishing a release, manually dispatch the Bump Versions workflow in GitHub Actions targeting the branch on which you want to change versions. Alternatively, you can run the `bump-versions` npm script. This workflow will create a branch named `bump-versions-<version>` from the target branch (or, if running the script, your current head) with the needed changes. Open a PR and merge that new branch into the branch on which you want to change versions.
+
+This workflow has the following inputs:
+
+- `newVersion`: enter the version you want to bump to (e.g. 0.3.0-alpha.0). Future changes will apply to this new version instead of to the version.
+- `newMarketingVersion`: a human-readable "marketing-level" version to call this version. It is best to set this only on the specific commit you intend to release so there is no confusion over which version is running. E.g. β1
+- `newMarketingVersionMoniker`: a human-readable "marketing-level" version moniker to call this version. It is best to set this only on the specific commit you intend to release so there is no confusion over which version is running. E.g. Developer Preview
+
+For example, to bump branch `my-branch` to version `0.2.0` with optional marketing version `β1` and optional marketing version moniker `Developer Preview`, run the following:
+
+```bash
+git checkout my-branch
+npm run bump-versions -- 0.2.0 --marketing-version β1 --marketing-version-moniker "Developer Preview"
+```
+
+Then create a PR and merge the `bump-versions-0.2.0` branch into `my-branch`. `my-branch` is now ready for release.
 
 ### Publishing problems
 

--- a/lib/build.ts
+++ b/lib/build.ts
@@ -287,6 +287,8 @@ console.log('Build steps enabled:', {
     // Update product details
     releaseAppPackage.name = productInfo.name;
     releaseAppPackage.version = productInfo.version;
+    releaseAppPackage.marketingVersion = productInfo.marketingVersion;
+    releaseAppPackage.marketingVersionMoniker = productInfo.marketingVersionMoniker;
     releaseAppPackage.description = productInfo.description;
     releaseAppPackage.author = productInfo.author;
 

--- a/lib/bump-versions.ts
+++ b/lib/bump-versions.ts
@@ -2,8 +2,6 @@ import fs from 'fs';
 import { checkForWorkingChanges } from './git.util';
 import { execCommand } from './build.util';
 
-// #region shared with https://github.com/paranext/paranext-extension-template/blob/main/lib/bump-versions.ts and https://github.com/paranext/paranext-multi-extension-template/blob/main/lib/bump-versions.ts
-
 // This script checks out a new branch, bumps the versions of all extensions in the repo,
 // and then commits the changes. It is generally expected that you will be on `main` when you run
 // this script.
@@ -11,13 +9,29 @@ import { execCommand } from './build.util';
 // Provide the new version as a command line argument e.g. `npx ts-node ./lib/bump-versions.ts 1.2.3-alpha.0`
 // Provide `--allow-working-changes` after the version to allow working changes to be part of making
 // the new version (useful if you want to do other things related to versioning before running this)
+// Provide `--marketing-version blah` after the version to set a marketing version
+// Provide `--marketing-version-moniker blah2` after the version to set a marketing version moniker
 
 const newVersion = process.argv[2];
 const shouldAllowWorkingChanges = process.argv.includes('--allow-working-changes');
 
+const newMarketingVersionIndex = process.argv.indexOf('--marketing-version');
+const newMarketingVersion =
+  newMarketingVersionIndex >= 0 && newMarketingVersionIndex < process.argv.length - 1
+    ? process.argv[newMarketingVersionIndex + 1]
+    : '';
+
+const newMarketingVersionMonikerIndex = process.argv.indexOf('--marketing-version-moniker');
+const newMarketingVersionMoniker =
+  newMarketingVersionMonikerIndex >= 0 && newMarketingVersionMonikerIndex < process.argv.length - 1
+    ? process.argv[newMarketingVersionMonikerIndex + 1]
+    : '';
+
+// #region shared with https://github.com/paranext/paranext-extension-template/blob/main/lib/bump-versions.ts and https://github.com/paranext/paranext-multi-extension-template/blob/main/lib/bump-versions.ts
+
 (async () => {
   // Make sure there are not working changes so we don't interfere with normal edits
-  if (!shouldAllowWorkingChanges && (await checkForWorkingChanges())) return 1;
+  if (!shouldAllowWorkingChanges && (await checkForWorkingChanges())) process.exit(1);
 
   const branchName = `bump-versions-${newVersion}`;
 
@@ -26,7 +40,7 @@ const shouldAllowWorkingChanges = process.argv.includes('--allow-working-changes
     await execCommand(`git checkout -b ${branchName}`);
   } catch (e) {
     console.error(`Error on git checkout: ${e}`);
-    return 1;
+    process.exit(1);
   }
 
   const bumpVersionCommand = `npm version ${newVersion} --git-tag-version false`;
@@ -36,17 +50,64 @@ const shouldAllowWorkingChanges = process.argv.includes('--allow-working-changes
     await execCommand(bumpVersionCommand);
   } catch (e) {
     console.error(`Error on bumping version: ${e}`);
-    return 1;
+    process.exit(1);
+  }
+
+  // Set marketing version and moniker in package.json if they exist
+  if (newMarketingVersion || newMarketingVersionMoniker) {
+    try {
+      // Read the package.json
+      const packageJsonPath = 'package.json';
+      const packageInfo = JSON.parse(await fs.promises.readFile(packageJsonPath, 'utf8'));
+      let didChangePackageInfo = false;
+      const updatedPackageInfo = { ...packageInfo };
+
+      if ('marketingVersion' in packageInfo) {
+        updatedPackageInfo.marketingVersion = newMarketingVersion;
+        didChangePackageInfo = true;
+      }
+      if ('marketingVersionMoniker' in packageInfo) {
+        updatedPackageInfo.marketingVersionMoniker = newMarketingVersionMoniker;
+        didChangePackageInfo = true;
+      }
+
+      if (didChangePackageInfo) {
+        // Write the updated package.json
+        await fs.promises.writeFile(
+          packageJsonPath,
+          `${JSON.stringify(updatedPackageInfo, undefined, 2)}\n`,
+          'utf8',
+        );
+      }
+    } catch (e) {
+      console.error(`Error while updating marketing version and moniker: ${e}`);
+      process.exit(1);
+    }
   }
 
   // #endregion
 
-  // Bump the version in productInfo.json if it exists
+  // Bump the versions in productInfo.json if they exist
   try {
     const productInfoPath = 'productInfo.json';
     const productInfo = JSON.parse(await fs.promises.readFile(productInfoPath, 'utf8'));
+    let didChangeProductInfo = false;
+    const updatedProductInfo = { ...productInfo };
+
     if ('version' in productInfo) {
-      const updatedProductInfo = { ...productInfo, version: newVersion };
+      updatedProductInfo.version = newVersion;
+      didChangeProductInfo = true;
+    }
+    if ('marketingVersion' in productInfo) {
+      updatedProductInfo.marketingVersion = newMarketingVersion;
+      didChangeProductInfo = true;
+    }
+    if ('marketingVersionMoniker' in productInfo) {
+      updatedProductInfo.marketingVersionMoniker = newMarketingVersionMoniker;
+      didChangeProductInfo = true;
+    }
+
+    if (didChangeProductInfo) {
       // Write the updated manifest to the extension directory
       await fs.promises.writeFile(
         productInfoPath,
@@ -56,7 +117,7 @@ const shouldAllowWorkingChanges = process.argv.includes('--allow-working-changes
     }
   } catch (e) {
     console.error(`Error on bumping productInfo version: ${e}`);
-    return 1;
+    process.exit(1);
   }
 
   // #region shared with https://github.com/paranext/paranext-extension-template/blob/main/lib/bump-versions.ts and https://github.com/paranext/paranext-multi-extension-template/blob/main/lib/bump-versions.ts
@@ -66,20 +127,20 @@ const shouldAllowWorkingChanges = process.argv.includes('--allow-working-changes
     await execCommand(`git commit -a -m "Bump versions to ${newVersion}"`);
   } catch (e) {
     console.error(`Error on committing changes: ${e}`);
-    return 1;
+    process.exit(1);
   }
   // Publish the branch and push the changes
   try {
     await execCommand(`git push -u origin HEAD`);
   } catch (e) {
     console.error(`Error on publishing branch and pushing changes: ${e}`);
-    return 1;
+    process.exit(1);
   }
   console.log(
     `Bumped versions to ${newVersion} and pushed to branch ${branchName}. Please create a pull request to merge this branch into main.`,
   );
 
-  return 0;
+  process.exit(0);
 })();
 
 // #endregion

--- a/lib/bump-versions.ts
+++ b/lib/bump-versions.ts
@@ -122,6 +122,14 @@ const newMarketingVersionMoniker =
 
   // #region shared with https://github.com/paranext/paranext-extension-template/blob/main/lib/bump-versions.ts and https://github.com/paranext/paranext-multi-extension-template/blob/main/lib/bump-versions.ts
 
+  // Format the changes
+  try {
+    await execCommand(`npm run format`);
+  } catch (e) {
+    console.error(`Error on formatting changes: ${e}`);
+    process.exit(1);
+  }
+
   // Commit the changes
   try {
     await execCommand(`git commit -a -m "Bump versions to ${newVersion}"`);

--- a/lib/product-info.data.ts
+++ b/lib/product-info.data.ts
@@ -67,6 +67,8 @@ const productName = partialProductInfo.productName ?? packageInfo.productName ??
 const productInfo: ProductInfo = Object.freeze({
   name: packageInfo.name,
   version: packageInfo.version,
+  marketingVersion: packageInfo.marketingVersion,
+  marketingVersionMoniker: packageInfo.marketingVersionMoniker,
   description: packageInfo.description,
   productName,
   productShortName: productName,

--- a/models/product-info.model.ts
+++ b/models/product-info.model.ts
@@ -17,6 +17,13 @@ export interface ProductInfo {
   name?: string;
   /** Version number for the product */
   version?: string;
+  /** Human-readable "marketing-level" version to call this version of the product e.g. β1 */
+  marketingVersion?: string;
+  /**
+   * Human-readable "marketing-level" version moniker to call this version of the product e.g.
+   * Developer Preview
+   */
+  marketingVersionMoniker?: string;
   /**
    * Short description explaining what the product is. Set to core's `release/app/package.json`
    * `description`. Not sure where this is used.

--- a/models/product-info.schema.json
+++ b/models/product-info.schema.json
@@ -12,6 +12,14 @@
       "description": "Version number for the product",
       "type": "string"
     },
+    "marketingVersion": {
+      "description": "Human-readable \"marketing-level\" version to call this version of the product e.g. β1",
+      "type": "string"
+    },
+    "marketingVersionMoniker": {
+      "description": "Human-readable \"marketing-level\" version moniker to call this version of the product e.g. Developer Preview",
+      "type": "string"
+    },
     "description": {
       "description": "Short description explaining what the product is. Set to core's `release/app/package.json` `description`. Not sure where this is used.",
       "type": "string"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "name": "platform-bible",
   "version": "0.0.1",
+  "marketingVersion": "",
+  "marketingVersionMoniker": "",
   "description": "Build scripts to create a white-label application on Platform.Bible",
   "keywords": ["electron", "platform", "bible", "translation", "typescript", "ts", "react", "node"],
   "homepage": "https://github.com/paranext/paranext#readme",


### PR DESCRIPTION
- Made marketing version and moniker independent from whatever is in `paranext-core` (now you can specify it in `package.json` or `productInfo.json` instead of not being able to set it from here)
- Auto-upload published releases to S3 bucket (opt-in)
- Run `npm run format` in `bump-versions.ts` to avoid failing format check
- Create release tag with the release so GitHub knows which target we're aiming for
- Created `bump-versions.yml` so we can bump versions without releasing when appropriate
  - See new section [Common Release Processes](https://docs.google.com/document/d/1YDNTLUweF3USLUtxaoozMNMFBgzEzha91otWp4VlUuw/edit?tab=t.0#heading=h.u4xypon9fsyy) in the release doc for more info
  - Can now set marketing version and moniker in that workflow

Note: this probably should have been a cherry-pick from https://github.com/paranext/paratext-10-studio/pull/74, but I forgot. Anyway, it should be almost the same. The only difference should be that this has `npm run format` in `bump-versions.ts` (apparently I missed putting that in `paratext-10-studio`. It will get in when I update from template there.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext/57)
<!-- Reviewable:end -->
