### PR TITLE
Use forked setup-macports step instead of original and replace macos-latest runner 

### DIFF
--- a/.github/workflows/package-main.yml
+++ b/.github/workflows/package-main.yml
@@ -3,7 +3,7 @@ name: Package
 # Make sure these match with the matrix.os values below
 env:
   OS_WINDOWS: windows-latest
-  OS_MACOS: macos-14
+  OS_MACOS: macos-latest
   # The Ubuntu version must align with the "core" version in electron-builder.json5 in paranext-core
   OS_LINUX: ubuntu-22.04
 
@@ -27,13 +27,13 @@ jobs:
     strategy:
       matrix:
         # Make sure these match with the env values above
-        os: [windows-latest, macos-14, ubuntu-22.04]
+        os: [windows-latest, macos-latest, ubuntu-22.04]
         dotnet_version: [8.0.x]
 
     steps:
       - name: Install MacPorts
         if: ${{ matrix.os == env.OS_MACOS }}
-        uses: melusina-org/setup-macports@v1
+        uses: paranext/setup-macports@v0.2.0
 
       - name: Update MacPorts ports tree
         if: ${{ matrix.os == env.OS_MACOS }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ run-name: Publish release v${{ github.event.inputs.version }} on ${{ github.head
 # Make sure these match with the matrix.os values below
 env:
   OS_WINDOWS: windows-latest
-  OS_MACOS: macos-14
+  OS_MACOS: macos-latest
   # The Ubuntu version must align with the "core" version in electron-builder.json5 in paranext-core
   OS_LINUX: ubuntu-22.04
 
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         # Make sure these match with the env values above
-        os: [windows-latest, macos-14, ubuntu-22.04]
+        os: [windows-latest, macos-latest, ubuntu-22.04]
         dotnet_version: [8.0.x]
 
     steps:
@@ -52,7 +52,7 @@ jobs:
 
       - name: Install MacPorts
         if: ${{ matrix.os == env.OS_MACOS }}
-        uses: melusina-org/setup-macports@v1
+        uses: paranext/setup-macports@v0.2.0
 
       - name: Update MacPorts ports tree
         if: ${{ matrix.os == env.OS_MACOS }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 # Make sure these match with the matrix.os values below
 env:
   OS_WINDOWS: windows-latest
-  OS_MACOS: macos-14
+  OS_MACOS: macos-latest
   # The Ubuntu version must align with the "core" version in electron-builder.json5 in paranext-core
   OS_LINUX: ubuntu-22.04
 
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         # Make sure these match with the env values above
-        os: [windows-latest, macos-14, ubuntu-22.04]
+        os: [windows-latest, macos-latest, ubuntu-22.04]
         dotnet_version: [8.0.x]
 
     steps:


### PR DESCRIPTION
For [PT-3398](https://paratextstudio.atlassian.net/browse/PT-3398)

Point the setup MacPorts step to the new repo, and put back `macos-latest`. This is needed so our scheduled builds do not fail.

[PT-3398]: https://paratextstudio.atlassian.net/browse/PT-3398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext/59)
<!-- Reviewable:end -->
